### PR TITLE
Update getHLS.sh

### DIFF
--- a/bash/hls-bulk-download/getHLS.sh
+++ b/bash/hls-bulk-download/getHLS.sh
@@ -140,16 +140,6 @@ do
              continue;;
 	esac
 
-	# Query twice for now: one for L30, one for S30 because of the inconsistency of data type.
-	# Once the data type problem is resolved, one of the queries will no longer be needed.
-	query_final="${query}&attribute[]=float,CLOUD_COVERAGE,,$CLOUD" 	# max 
-	if [ $WGET = true ]
-	then
-		wget -q "${query_final}&attribute[]=string,MGRS_TILE_ID,$tile" -O - >>$meta
-	else
-		curl -s "${query_final}&attribute[]=string,MGRS_TILE_ID,$tile" >>$meta
-	fi
-
 	query_final="${query}&attribute[]=int,CLOUD_COVERAGE,,$CLOUD" 		# max 
 	if [ $WGET = true ]
 	then


### PR DESCRIPTION
It seems the inconsistance mentioned in original code commentary is resolved. The request:
```
wget -q --retry-connrefused --waitretry=1 --read-timeout=10 --timeout=10 -t 0 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=C2021957295-LPCLOUD&collection_concept_id=C2021957657-LPCLOUD&page_size=2000&temporal=2013-01-01T00:00:00Z,2030-01-01T23:59:59Z&attribute[]=int,SPATIAL_COVERAGE,0,&attribute[]=int,CLOUD_COVERAGE,,100&attribute[]=string,MGRS_TILE_ID,18TXL' -O -
```
return plenty of data for Long Island (18TXL) between 2013-2030 . While request:

```
wget -q --retry-connrefused --waitretry=1 --read-timeout=10 --timeout=10 -t 0 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=C2021957295-LPCLOUD&collection_concept_id=C2021957657-LPCLOUD&page_size=2000&temporal=2013-01-01T00:00:00Z,2030-01-01T23:59:59Z&attribute[]=float,SPATIAL_COVERAGE,0,&attribute[]=int,CLOUD_COVERAGE,,100&attribute[]=string,MGRS_TILE_ID,18TXL' -O -
```
return an empty set.  They differ only by a type of CLOUD_COVERAGE attribute.
So I suppose the float version of this request is discontinued.