### PR TITLE
update create_quality_mask function

### DIFF
--- a/python/tutorials/EVI_timeseries_with_odc_stac.ipynb
+++ b/python/tutorials/EVI_timeseries_with_odc_stac.ipynb
@@ -498,7 +498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +509,7 @@
     "    \"\"\"\n",
     "    mask_array = np.zeros((quality_data.shape[0], quality_data.shape[1]))\n",
     "    # Remove/Mask Fill Values and Convert to Integer\n",
-    "    quality_data = np.nan_to_num(quality_data.copy(), nan=0).astype(np.int8)\n",
+    "    quality_data = np.nan_to_num(quality_data.copy(), nan=255).astype(np.int8)\n",
     "    for bit in bit_nums:\n",
     "        # Create a Single Binary Mask Layer\n",
     "        mask_temp = np.array(quality_data) & 1 << bit > 0\n",
@@ -575,7 +575,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hls_odc",
+   "display_name": "lpdaac_vitals",
    "language": "python",
    "name": "python3"
   },
@@ -589,7 +589,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/python/tutorials/HLS_Tutorial.ipynb
+++ b/python/tutorials/HLS_Tutorial.ipynb
@@ -3419,7 +3419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3430,7 +3430,7 @@
     "    \"\"\"\n",
     "    mask_array = np.zeros((quality_data.shape[0], quality_data.shape[1]))\n",
     "    # Remove/Mask Fill Values and Convert to Integer\n",
-    "    quality_data = np.nan_to_num(quality_data, 0).astype(np.int8)\n",
+    "    quality_data = np.nan_to_num(quality_data, 255).astype(np.int8)\n",
     "    for bit in bit_nums:\n",
     "        # Create a Single Binary Mask Layer\n",
     "        mask_temp = np.array(quality_data) & 1 << bit > 0\n",


### PR DESCRIPTION
This fixes an issue where fill-values (255) from the HLS Fmask layer were not being used properly during creation of a quality mask with the `create_quality_mask` function.